### PR TITLE
Problem with resource path for Windows OS

### DIFF
--- a/src/main/java/org/sevntu/maven/plugin/dsm/DsmReportEngine.java
+++ b/src/main/java/org/sevntu/maven/plugin/dsm/DsmReportEngine.java
@@ -263,7 +263,7 @@ public class DsmReportEngine {
 		// check directory
 		if (aDirName != null && !aDirName.isEmpty()) {
 			new File(aSiteDirectory + aDirName).mkdirs();
-			fileName = aDirName + File.separator + aFileName;
+			fileName = aDirName + "/" + aFileName;
 		} else {
 			fileName = aFileName;
 		}
@@ -285,7 +285,7 @@ public class DsmReportEngine {
 		InputStream inputStream = null;
 		OutputStream outputStream = null;
 		try {
-			inputStream = DsmReportEngine.class.getResourceAsStream(File.separator + aFileName);
+			inputStream = DsmReportEngine.class.getResourceAsStream("/" + aFileName);
 			outputStream = new FileOutputStream(new File(aSiteDirectory + aFileName));
 
 			int numberOfBytes;


### PR DESCRIPTION
Windows return '\' for File.separator as a result 'getResourceAsStream' returns null. We
shouldn't use File.separator when we use getResourceAsStream method. We
should use '/' as it says in docs:
http://docs.oracle.com/javase/7/docs/api/java/lang/Class.html#getResourceAsStream%28java.lang.String%29
