### PR TITLE
minor: vertical text fixed in css

### DIFF
--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -119,11 +119,9 @@ tr td {
 }
 
 .vertical_text {
-	-moz-transform: rotate(270deg);
+	transform: rotate(270deg);
 	-webkit-transform: rotate(270deg);
-	-o-transform: rotate(270deg);
-	-ms-transform: rotate(180deg);
-	writing-mode: tb-rl;
+	-ms-transform: rotate(270deg);
 	display: inline-block;
 	padding-bottom: 5px;
 	width: 20px;


### PR DESCRIPTION
tested in:
FF V 45.0
Chrome Version 48.0.2564.116 (64-bit)
and Safari Version 9.0.3 (11601.4.4)