### PR TITLE
#31 Updated the DSM report plugin to support Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: java
 
 jdk:
-  #- openjdk6
-  #- openjdk7
-  - oraclejdk7
   - oraclejdk8
 
 install: mvn install -Dgpg.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.github.sevntu-checkstyle</groupId>
 	<artifactId>dsm-maven-plugin</artifactId>
-	<version>2.1.4</version>
+	<version>2.2.0</version>
 
 	<packaging>maven-plugin</packaging>
 	<name>DSM maven plugin</name>
@@ -57,9 +57,15 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.dtangler</groupId>
+			<groupId>org.hjug.dtangler.domain</groupId>
+			<artifactId>dtangler-domain</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hjug.dtangler.core</groupId>
 			<artifactId>dtangler-core</artifactId>
-			<version>2.0.0</version>
+			<version>2.1.0</version>
 		</dependency>
 
 		<dependency>
@@ -120,8 +126,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 
@@ -154,6 +160,18 @@
 	                </execution>
 	            </executions>
 	        </plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.5.1</version>
+				<executions>
+					<execution>
+						<id>default-descriptor</id>
+						<phase>process-classes</phase>
+					</execution>
+				</executions>
+			</plugin>
 
 	        <plugin>
 	            <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/sevntu/maven/plugin/dsm/DsmHtmlWriter.java
+++ b/src/main/java/org/sevntu/maven/plugin/dsm/DsmHtmlWriter.java
@@ -11,11 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.dtangler.core.analysisresult.AnalysisResult;
-import org.dtangler.core.analysisresult.Violation.Severity;
-import org.dtangler.core.dsm.Dsm;
-import org.dtangler.core.dsm.DsmCell;
-import org.dtangler.core.dsm.DsmRow;
+import org.hjug.dtangler.core.analysisresult.AnalysisResult;
+import org.hjug.dtangler.core.analysisresult.Violation.Severity;
+import org.hjug.dtangler.core.dsm.Dsm;
+import org.hjug.dtangler.core.dsm.DsmCell;
+import org.hjug.dtangler.core.dsm.DsmRow;
 
 import com.google.common.base.Strings;
 
@@ -110,7 +110,7 @@ public class DsmHtmlWriter {
 			throw new IllegalArgumentException("List of package names should not be null");
 		}
 
-		Map<String, Object> dataModel = new HashMap<String, Object>();
+		Map<String, Object> dataModel = new HashMap<>();
 		dataModel.put("aPackageNames", aPackageNames);
 
 		writeModelToFile("packages", FTL_PACKAGES_MENU, dataModel);

--- a/src/main/java/org/sevntu/maven/plugin/dsm/DsmReportEngine.java
+++ b/src/main/java/org/sevntu/maven/plugin/dsm/DsmReportEngine.java
@@ -12,18 +12,18 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.reporting.MavenReportException;
-import org.dtangler.core.analysis.configurableanalyzer.ConfigurableDependencyAnalyzer;
-import org.dtangler.core.analysisresult.AnalysisResult;
-import org.dtangler.core.configuration.Arguments;
-import org.dtangler.core.dependencies.Dependable;
-import org.dtangler.core.dependencies.Dependencies;
-import org.dtangler.core.dependencies.DependencyGraph;
-import org.dtangler.core.dependencies.Scope;
-import org.dtangler.core.dependencyengine.DependencyEngine;
-import org.dtangler.core.dependencyengine.DependencyEngineFactory;
-import org.dtangler.core.dsm.Dsm;
-import org.dtangler.core.dsm.DsmRow;
-import org.dtangler.core.dsmengine.DsmEngine;
+import org.hjug.dtangler.core.analysis.configurableanalyzer.ConfigurableDependencyAnalyzer;
+import org.hjug.dtangler.core.analysisresult.AnalysisResult;
+import org.hjug.dtangler.core.configuration.Arguments;
+import org.hjug.dtangler.core.dependencies.Dependable;
+import org.hjug.dtangler.core.dependencies.Dependencies;
+import org.hjug.dtangler.core.dependencies.DependencyGraph;
+import org.hjug.dtangler.core.dependencies.Scope;
+import org.hjug.dtangler.core.dependencyengine.DependencyEngine;
+import org.hjug.dtangler.core.dependencyengine.DependencyEngineFactory;
+import org.hjug.dtangler.core.dsm.Dsm;
+import org.hjug.dtangler.core.dsm.DsmRow;
+import org.hjug.dtangler.core.dsmengine.DsmEngine;
 
 import com.google.common.base.Strings;
 
@@ -96,7 +96,7 @@ public class DsmReportEngine {
 	 */
 	private static List<String> getPackageNames(final Dsm aDsm) {
 		List<DsmRow> dsmRowList = aDsm.getRows();
-		List<String> packageNames = new ArrayList<String>();
+		List<String> packageNames = new ArrayList<>();
 		for (DsmRow dsmRow : dsmRowList) {
 			packageNames.add(dsmRow.getDependee().toString());
 		}
@@ -113,7 +113,7 @@ public class DsmReportEngine {
 	 * @return Set of Dependables
 	 */
 	private static Set<Dependable> getDependablesByRowIndex(final Dsm aDsm, final int aRow) {
-		Set<Dependable> result = new HashSet<Dependable>();
+		Set<Dependable> result = new HashSet<>();
 		result.add(aDsm.getRows().get(aRow).getDependee());
 		return result;
 	}
@@ -139,7 +139,7 @@ public class DsmReportEngine {
 	public void report() throws Exception {
 		dsmHtmlWriter = new DsmHtmlWriter(outputDirectory, obfuscatePackageNames);
 
-		List<String> sourcePathList = new ArrayList<String>();
+		List<String> sourcePathList = new ArrayList<>();
 		sourcePathList.add(sourceDirectory);
 
 		report(sourcePathList);
@@ -257,7 +257,7 @@ public class DsmReportEngine {
 	 * @throws Exception
 	 */
 	private static void copyFileToSiteFolder(final String aSiteDirectory, final String aDirName,
-			final String aFileName) throws Exception {
+			final String aFileName) {
 		String fileName;
 
 		// check directory
@@ -280,14 +280,9 @@ public class DsmReportEngine {
 	 *            File name
 	 * @throws Exception
 	 */
-	private static void copyFileToSiteFolder(final String aSiteDirectory, final String aFileName)
-			throws Exception {
-		InputStream inputStream = null;
-		OutputStream outputStream = null;
-		try {
-			inputStream = DsmReportEngine.class.getResourceAsStream("/" + aFileName);
-			outputStream = new FileOutputStream(new File(aSiteDirectory + aFileName));
-
+	private static void copyFileToSiteFolder(final String aSiteDirectory, final String aFileName) {
+		try (InputStream inputStream = DsmReportEngine.class.getResourceAsStream("/" + aFileName);
+			 OutputStream outputStream = new FileOutputStream(new File(aSiteDirectory + aFileName))) {
 			int numberOfBytes;
 			byte[] buffer = new byte[1024];
 			while ((numberOfBytes = inputStream.read(buffer)) > 0) {
@@ -300,9 +295,6 @@ public class DsmReportEngine {
 			} else {
 				throw new RuntimeException("Unable to copy source file. " + e.getMessage(), e);
 			}
-		} finally {
-			inputStream.close();
-			outputStream.close();
 		}
 	}
 }

--- a/src/test/java/org/sevntu/maven/plugin/dsm/DsmHtmlWriterTest.java
+++ b/src/test/java/org/sevntu/maven/plugin/dsm/DsmHtmlWriterTest.java
@@ -10,11 +10,11 @@ import java.util.Set;
 
 import junit.framework.Assert;
 
-import org.dtangler.core.analysisresult.AnalysisResult;
-import org.dtangler.core.analysisresult.Violation;
-import org.dtangler.core.dependencies.Dependency;
-import org.dtangler.core.dsm.Dsm;
-import org.dtangler.core.dsm.DsmRow;
+import org.hjug.dtangler.core.analysisresult.AnalysisResult;
+import org.hjug.dtangler.core.analysisresult.Violation;
+import org.hjug.dtangler.core.dependencies.Dependency;
+import org.hjug.dtangler.core.dsm.Dsm;
+import org.hjug.dtangler.core.dsm.DsmRow;
 import org.junit.Test;
 
 


### PR DESCRIPTION
Updated the DSM plugin to support Java 8 by updating the dtangler dependency and updating the package imports.  I have also updated the Java version in the compiler plugin to use Java 8 and take advantage of some of the newer Java features (only minor code changes).

I added the maven-plugin-plugin since the mojo descriptors weren't being generated correctly.

I have successfully tested locally against a Java 8 project.

Will need to be compiled with a Java 8 compiler.